### PR TITLE
Fix missing JMS API in the classpath when connecting to the Kie Server

### DIFF
--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-showcase/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-showcase/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.1">
+  <deployment>
+    <dependencies>
+      <module name="javax.jms.api"/>
+    </dependencies>
+  </deployment>
+</jboss-deployment-structure>


### PR DESCRIPTION
As JMS is not in the classpath a ClassNotFoundException: javax.jms.JMSException is thrown when creating a client connection.