### PR TITLE
JBPM-5675 - Prevent start process instance options from case definitions

### DIFF
--- a/jbpm-wb-forms/jbpm-wb-forms-client/pom.xml
+++ b/jbpm-wb-forms/jbpm-wb-forms-client/pom.xml
@@ -38,6 +38,10 @@
       <artifactId>gwtbootstrap3</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.gwtbootstrap3</groupId>
+      <artifactId>gwtbootstrap3-extras</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/jbpm-wb-forms/jbpm-wb-forms-client/src/main/java/org/jbpm/workbench/forms/client/display/process/QuickNewProcessInstancePopup.ui.xml
+++ b/jbpm-wb-forms/jbpm-wb-forms-client/src/main/java/org/jbpm/workbench/forms/client/display/process/QuickNewProcessInstancePopup.ui.xml
@@ -19,7 +19,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
              xmlns:g="urn:import:com.google.gwt.user.client.ui"
-             xmlns:b="urn:import:org.gwtbootstrap3.client.ui">
+             xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+             xmlns:s="urn:import:org.gwtbootstrap3.extras.select.client.ui">
 
     <ui:with field="i18n" type="org.jbpm.workbench.forms.client.i18n.Constants"/>
 
@@ -29,21 +30,12 @@
                 <g:FlowPanel ui:field="basicForm">
                     <b:Form type="HORIZONTAL">
                         <b:FieldSet>
-                            <b:FormGroup ui:field="processDeploymentIdControlGroup">
-                                <b:FormLabel addStyleNames="col-md-4">
-                                    <ui:text from="{i18n.Process_DeploymentId}"/>
-                                </b:FormLabel>
-                                <b:Column size="MD_8">
-                                    <b:ListBox ui:field="processDeploymentIdListBox"/>
-                                    <b:HelpBlock ui:field="processDeploymentIdHelpLabel"/>
-                                </b:Column>
-                            </b:FormGroup>
                             <b:FormGroup ui:field="processDefinitionsControlGroup">
                                 <b:FormLabel addStyleNames="col-md-4">
                                     <ui:text from="{i18n.Process_Definition}"/>
                                 </b:FormLabel>
                                 <b:Column size="MD_8">
-                                    <b:ListBox ui:field="processDefinitionsListBox"/>
+                                    <s:Select ui:field="processDefinitionsListBox"/>
                                     <b:HelpBlock ui:field="processDefinitionsHelpLabel"/>
                                 </b:Column>
                             </b:FormGroup>

--- a/jbpm-wb-forms/jbpm-wb-forms-client/src/main/resources/org/jbpm/workbench/forms/JbpmWorkbenchFormsClient.gwt.xml
+++ b/jbpm-wb-forms/jbpm-wb-forms-client/src/main/resources/org/jbpm/workbench/forms/JbpmWorkbenchFormsClient.gwt.xml
@@ -38,6 +38,8 @@
 
   <inherits name="org.kie.workbench.common.forms.dynamic.DynamicFormsAPI"/>
 
+  <inherits name="org.gwtbootstrap3.extras.select.Select"/>
+
   <source path="client"/>
 
 </module>

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-api/src/main/java/org/jbpm/workbench/pr/events/ProcessDefSelectionEvent.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-api/src/main/java/org/jbpm/workbench/pr/events/ProcessDefSelectionEvent.java
@@ -20,11 +20,12 @@ import org.jboss.errai.common.client.api.annotations.Portable;
 
 @Portable
 public class ProcessDefSelectionEvent {
+
     private String processId;
     private String processDefName;
     private String deploymentId;
-
     private String serverTemplateId;
+    private boolean dynamic;
 
     public ProcessDefSelectionEvent() {
     }
@@ -33,16 +34,12 @@ public class ProcessDefSelectionEvent {
         this.processId = processId;
     }
 
-    public ProcessDefSelectionEvent(String processId, String deploymentId) {
-        this.processId = processId;
-        this.deploymentId = deploymentId;
-    }
-
-    public ProcessDefSelectionEvent(String processId, String deploymentId, String serverTemplateId, String processDefName) {
-        this.processId = processId;
+    public ProcessDefSelectionEvent(String processId, String deploymentId, String serverTemplateId, String processDefName, boolean dynamic) {
+        this(processId);
         this.deploymentId = deploymentId;
         this.serverTemplateId = serverTemplateId;
         this.processDefName = processDefName;
+        this.dynamic = dynamic;
     }
 
     public String getProcessId() {
@@ -77,5 +74,11 @@ public class ProcessDefSelectionEvent {
         this.serverTemplateId = serverTemplateId;
     }
 
+    public boolean isDynamic() {
+        return dynamic;
+    }
 
+    public void setDynamic(boolean dynamic) {
+        this.dynamic = dynamic;
+    }
 }

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-api/src/main/java/org/jbpm/workbench/pr/model/ProcessSummary.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-api/src/main/java/org/jbpm/workbench/pr/model/ProcessSummary.java
@@ -23,72 +23,48 @@ import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jbpm.workbench.common.model.GenericSummary;
 
 @Portable
-public class ProcessSummary extends GenericSummary{
+public class ProcessSummary extends GenericSummary {
 
     private String processDefId;
     private String processDefName;
-    private String packageName;
-    private String type;
     private String version;
-    private String originalPath;
     private String deploymentId;
-    private String encodedProcessSource;
-
+    private boolean dynamic;
     private Map<String, String[]> associatedEntities;
-
     private Map<String, String> serviceTasks;
-
     private Map<String, String> processVariables;
-
     private Collection<String> reusableSubProcesses;
 
     public ProcessSummary() {
     }
 
-    public ProcessSummary(String processDefId, String processDefName, String deploymentId, String packageName, String type, String version,
-            String originalpath, String processSource) {
-        this.id = processDefId;    
-        this.name = processDefName;
+    public ProcessSummary(String processDefId,
+                          String processDefName,
+                          String deploymentId,
+                          String version,
+                          boolean dynamic) {
+        super(processDefId, processDefName);
         this.processDefId = processDefId;
         this.processDefName = processDefName;
         this.deploymentId = deploymentId;
-        this.packageName = packageName;
-        this.type = type;
         this.version = version;
-        this.originalPath = originalpath;
-        this.encodedProcessSource = processSource;
+        this.dynamic = dynamic;
     }
 
     public String getProcessDefId() {
-      return processDefId;
+        return processDefId;
     }
 
     public void setProcessDefId(String processDefId) {
-      this.processDefId = processDefId;
+        this.processDefId = processDefId;
     }
 
     public String getProcessDefName() {
-      return processDefName;
+        return processDefName;
     }
 
     public void setProcessDefName(String processDefName) {
-      this.processDefName = processDefName;
-    }
-
-    public String getPackageName() {
-        return packageName;
-    }
-
-    public void setPackageName(String packageName) {
-        this.packageName = packageName;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+        this.processDefName = processDefName;
     }
 
     public String getVersion() {
@@ -105,22 +81,6 @@ public class ProcessSummary extends GenericSummary{
 
     public void setDeploymentId(String deploymentId) {
         this.deploymentId = deploymentId;
-    }
-
-    public String getOriginalPath() {
-        return originalPath;
-    }
-
-    public void setOriginalPath(String originalPath) {
-        this.originalPath = originalPath;
-    }
-
-    public String getEncodedProcessSource() {
-        return encodedProcessSource;
-    }
-
-    public void setEncodedProcessSource(String encodedProcessSource) {
-        this.encodedProcessSource = encodedProcessSource;
     }
 
     public Map<String, String[]> getAssociatedEntities() {
@@ -153,5 +113,28 @@ public class ProcessSummary extends GenericSummary{
 
     public void setReusableSubProcesses(Collection<String> reusableSubProcesses) {
         this.reusableSubProcesses = reusableSubProcesses;
+    }
+
+    public boolean isDynamic() {
+        return dynamic;
+    }
+
+    public void setDynamic(Boolean dynamic) {
+        this.dynamic = dynamic;
+    }
+
+    @Override
+    public String toString() {
+        return "ProcessSummary{" +
+                "processDefId='" + processDefId + '\'' +
+                ", processDefName='" + processDefName + '\'' +
+                ", version='" + version + '\'' +
+                ", deploymentId='" + deploymentId + '\'' +
+                ", dynamic=" + dynamic +
+                ", associatedEntities=" + associatedEntities +
+                ", serviceTasks=" + serviceTasks +
+                ", processVariables=" + processVariables +
+                ", reusableSubProcesses=" + reusableSubProcesses +
+                '}';
     }
 }

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/ProcessSummaryMapper.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/ProcessSummaryMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.workbench.pr.backend.server;
+
+import java.util.function.Function;
+
+import org.jbpm.workbench.pr.model.ProcessSummary;
+import org.kie.server.api.model.definition.ProcessDefinition;
+
+public class ProcessSummaryMapper implements Function<ProcessDefinition, ProcessSummary> {
+
+    @Override
+    public ProcessSummary apply(final ProcessDefinition definition) {
+        if(definition == null){
+            return null;
+        }
+
+        final ProcessSummary summary = new ProcessSummary(definition.getId(),
+                definition.getName(),
+                definition.getContainerId(),
+                definition.getVersion(),
+                definition.isDynamic());
+
+        summary.setAssociatedEntities(definition.getAssociatedEntities());
+        summary.setProcessVariables(definition.getProcessVariables());
+        summary.setReusableSubProcesses(definition.getReusableSubProcesses());
+        summary.setServiceTasks(definition.getServiceTasks());
+
+        return summary;
+    }
+}

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/RemoteProcessRuntimeDataServiceImpl.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/RemoteProcessRuntimeDataServiceImpl.java
@@ -147,17 +147,7 @@ public class RemoteProcessRuntimeDataServiceImpl extends AbstractKieServerServic
 
         List<ProcessDefinition> processes = queryServicesClient.findProcesses(page, pageSize, sort, sortOrder);
 
-        return processes
-                .stream()
-                .map(definition -> new ProcessSummary(definition.getId(),
-                        definition.getName(),
-                        definition.getContainerId(),
-                        definition.getPackageName(),
-                        "",
-                        definition.getVersion(),
-                        "",
-                        ""))
-                .collect(toList());
+        return processes.stream().map(new ProcessSummaryMapper()).collect(toList());
     }
 
     @Override
@@ -170,21 +160,7 @@ public class RemoteProcessRuntimeDataServiceImpl extends AbstractKieServerServic
 
         ProcessDefinition definition = queryServicesClient.getProcessDefinition(processDefinitionKey.getDeploymentId(), processDefinitionKey.getProcessId());
 
-        ProcessSummary summary = new ProcessSummary(definition.getId(),
-                definition.getName(),
-                definition.getContainerId(),
-                definition.getPackageName(),
-                "",
-                definition.getVersion(),
-                "",
-                "");
-
-        summary.setAssociatedEntities(definition.getAssociatedEntities());
-        summary.setProcessVariables(definition.getProcessVariables());
-        summary.setReusableSubProcesses(definition.getReusableSubProcesses());
-        summary.setServiceTasks(definition.getServiceTasks());
-
-        return summary;
+        return new ProcessSummaryMapper().apply(definition);
     }
 
     @Override
@@ -197,17 +173,7 @@ public class RemoteProcessRuntimeDataServiceImpl extends AbstractKieServerServic
 
         List<ProcessDefinition> processes = queryServicesClient.findProcesses(textSearch, page, pageSize, sort, sortOrder);
 
-        return processes
-                .stream()
-                .map(definition -> new ProcessSummary(definition.getId(),
-                        definition.getName(),
-                        definition.getContainerId(),
-                        definition.getPackageName(),
-                        "",
-                        definition.getVersion(),
-                        "",
-                        ""))
-                .collect(toList());
+        return processes.stream().map(new ProcessSummaryMapper()).collect(toList());
     }
 
     @Override
@@ -220,21 +186,7 @@ public class RemoteProcessRuntimeDataServiceImpl extends AbstractKieServerServic
 
         ProcessDefinition definition = queryServicesClient.findProcessByContainerIdProcessId(containerId, processId);
 
-        ProcessSummary summary = new ProcessSummary(definition.getId(),
-                definition.getName(),
-                definition.getContainerId(),
-                definition.getPackageName(),
-                "",
-                definition.getVersion(),
-                "",
-                "");
-
-        summary.setAssociatedEntities(definition.getAssociatedEntities());
-        summary.setProcessVariables(definition.getProcessVariables());
-        summary.setReusableSubProcesses(definition.getReusableSubProcesses());
-        summary.setServiceTasks(definition.getServiceTasks());
-
-        return summary;
+        return new ProcessSummaryMapper().apply(definition);
     }
 
     @Override

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/test/java/org/jbpm/workbench/pr/backend/server/ProcessSummaryMapperTest.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/test/java/org/jbpm/workbench/pr/backend/server/ProcessSummaryMapperTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.workbench.pr.backend.server;
+
+import org.jbpm.workbench.pr.model.ProcessSummary;
+import org.junit.Test;
+import org.kie.server.api.model.definition.ProcessDefinition;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.*;
+
+public class ProcessSummaryMapperTest {
+
+    public static void assertProcessSummary(final ProcessDefinition pd, final ProcessSummary ps) {
+        assertNotNull(ps);
+
+        assertEquals(pd.getId(), ps.getId());
+        assertEquals(pd.getId(), ps.getProcessDefId());
+        assertEquals(pd.getName(), ps.getName());
+        assertEquals(pd.getName(), ps.getProcessDefName());
+        assertEquals(pd.isDynamic(), ps.isDynamic());
+        assertEquals(pd.getVersion(), ps.getVersion());
+        assertEquals(pd.getContainerId(), ps.getDeploymentId());
+        assertEquals(pd.getAssociatedEntities(), ps.getAssociatedEntities());
+        assertEquals(pd.getProcessVariables(), ps.getProcessVariables());
+        assertEquals(pd.getReusableSubProcesses(), ps.getReusableSubProcesses());
+        assertEquals(pd.getServiceTasks(), ps.getServiceTasks());
+    }
+
+    @Test
+    public void testProcessSummaryMapper_mapProcessSummary() {
+        final ProcessDefinition pd = new ProcessDefinition();
+        pd.setName("definitionName");
+        pd.setId("definitionId");
+        pd.setDynamic(true);
+        pd.setContainerId("containerId");
+        pd.setVersion("1.0");
+        pd.setAssociatedEntities(singletonMap("e1", new String[0]));
+        pd.setProcessVariables(singletonMap("initiator", "String"));
+        pd.setReusableSubProcesses(singletonList("processOne"));
+        pd.setServiceTasks(singletonMap("email", "org.jbpm"));
+
+        assertProcessSummary(pd, new ProcessSummaryMapper().apply(pd));
+    }
+
+    @Test
+    public void testProcessSummaryMapper_mapNull() {
+        assertNull(new ProcessSummaryMapper().apply(null));
+    }
+
+}

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/test/java/org/jbpm/workbench/pr/backend/server/RemoteProcessRuntimeDataServiceImplTest.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/test/java/org/jbpm/workbench/pr/backend/server/RemoteProcessRuntimeDataServiceImplTest.java
@@ -18,17 +18,57 @@ package org.jbpm.workbench.pr.backend.server;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.List;
 
-import org.jbpm.workbench.pr.backend.server.RemoteProcessRuntimeDataServiceImpl;
+import org.jbpm.workbench.ks.integration.KieServerIntegration;
+import org.jbpm.workbench.pr.model.ProcessDefinitionKey;
+import org.jbpm.workbench.pr.model.ProcessSummary;
 import org.jbpm.workbench.pr.service.ProcessRuntimeDataService;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.server.api.model.definition.ProcessDefinition;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.client.ProcessServicesClient;
+import org.kie.server.client.QueryServicesClient;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.lang.String.format;
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+import static java.util.Collections.singletonList;
+import static org.jbpm.workbench.pr.backend.server.ProcessSummaryMapperTest.assertProcessSummary;
 
+@RunWith(MockitoJUnitRunner.class)
 public class RemoteProcessRuntimeDataServiceImplTest {
 
-    RemoteProcessRuntimeDataServiceImpl service = new RemoteProcessRuntimeDataServiceImpl();
+    @Mock
+    private KieServerIntegration kieServerIntegration;
+
+    @Mock
+    private QueryServicesClient queryServicesClient;
+
+    @Mock
+    private ProcessServicesClient processServicesClient;
+
+    @InjectMocks
+    private RemoteProcessRuntimeDataServiceImpl service;
+
+    private final String processId = "processId";
+    private final String containerId = "containerId";
+    private final String serverTemplateId = "serverTemplateId";
+
+    @Before
+    public void setup(){
+        final KieServicesClient kieServicesClient = mock(KieServicesClient.class);
+        when(kieServerIntegration.getServerClient(anyString())).thenReturn(kieServicesClient);
+        when(kieServicesClient.getServicesClient(QueryServicesClient.class)).thenReturn(queryServicesClient);
+        when(kieServicesClient.getServicesClient(ProcessServicesClient.class)).thenReturn(processServicesClient);
+    }
 
     @Test
     public void testInvalidServerTemplate() throws Exception {
@@ -53,6 +93,58 @@ public class RemoteProcessRuntimeDataServiceImplTest {
         } else {
             assertNull(format("Returned object for method %s should be null", method.getName()), result);
         }
+    }
+
+    @Test
+    public void testGetProcesses(){
+        final ProcessDefinition def = ProcessDefinition.builder().id(processId).build();
+
+        when(queryServicesClient.findProcesses(0, 10, "", true)).thenReturn(singletonList(def));
+
+        final List<ProcessSummary> summaries = service.getProcesses(serverTemplateId, 0, 10, "", true);
+
+        assertNotNull(summaries);
+        assertEquals(1, summaries.size());
+        assertProcessSummary(def, summaries.get(0));
+    }
+
+    @Test
+    public void testGetProcessesByFilter(){
+        final ProcessDefinition def = ProcessDefinition.builder().id(processId).build();
+
+        when(queryServicesClient.findProcesses("filter", 0, 10, "", true)).thenReturn(singletonList(def));
+
+        final List<ProcessSummary> summaries = service.getProcessesByFilter(serverTemplateId, "filter", 0, 10, "", true);
+
+        assertNotNull(summaries);
+        assertEquals(1, summaries.size());
+        assertProcessSummary(def, summaries.get(0));
+    }
+
+    @Test
+    public void testGetProcessesByContainerIdProcessId(){
+        final ProcessDefinition def = ProcessDefinition.builder().id(processId).build();
+
+        when(queryServicesClient.findProcessByContainerIdProcessId(containerId, processId)).thenReturn(def);
+
+        final ProcessSummary summary = service.getProcessesByContainerIdProcessId(serverTemplateId, containerId, processId);
+
+        assertNotNull(summary);
+        assertProcessSummary(def, summary);
+    }
+
+    @Test
+    public void testGetProcess(){
+        final ProcessDefinition def = ProcessDefinition.builder().id(processId).build();
+
+        when(processServicesClient.getProcessDefinition(containerId, processId)).thenReturn(def);
+
+        final ProcessDefinitionKey pdk = new ProcessDefinitionKey(serverTemplateId, containerId, processId);
+
+        final ProcessSummary summary = service.getProcess(serverTemplateId, pdk);
+
+        assertNotNull(summary);
+        assertProcessSummary(def, summary);
     }
 
 }

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/details/BaseProcessDefDetailsPresenter.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/details/BaseProcessDefDetailsPresenter.java
@@ -21,7 +21,6 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import org.jbpm.workbench.pr.events.ProcessDefSelectionEvent;
 import org.jbpm.workbench.pr.events.ProcessDefStyleEvent;
-import org.uberfire.backend.vfs.Path;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.IsWidget;
 
@@ -44,13 +43,6 @@ public abstract class BaseProcessDefDetailsPresenter {
 
         HTML getDeploymentIdText();
 
-        void setProcessAssetPath( Path processAssetPath );
-
-        void setEncodedProcessSource( String encodedProcessSource );
-
-        Path getProcessAssetPath();
-
-        String getEncodedProcessSource();
     }
 
     protected void changeStyleRow( String processDefName, String processDefVersion ) {

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/details/BaseProcessDefDetailsViewImpl.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/details/BaseProcessDefDetailsViewImpl.java
@@ -24,7 +24,6 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTML;
 import org.gwtbootstrap3.client.ui.FormLabel;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
-import org.uberfire.backend.vfs.Path;
 import org.uberfire.workbench.events.NotificationEvent;
 
 public abstract class BaseProcessDefDetailsViewImpl extends Composite implements
@@ -57,10 +56,6 @@ public abstract class BaseProcessDefDetailsViewImpl extends Composite implements
     @Inject
     private Event<NotificationEvent> notification;
 
-    private Path processAssetPath;
-
-    private String encodedProcessSource;
-
     @PostConstruct
     public void initView() {
         init();
@@ -71,7 +66,6 @@ public abstract class BaseProcessDefDetailsViewImpl extends Composite implements
     @Override
     public void displayNotification( String text ) {
         notification.fire( new NotificationEvent( text ) );
-
     }
 
     @Override
@@ -85,25 +79,8 @@ public abstract class BaseProcessDefDetailsViewImpl extends Composite implements
     }
 
     @Override
-    public void setProcessAssetPath( Path processAssetPath ) {
-        this.processAssetPath = processAssetPath;
-    }
-
-    @Override
-    public void setEncodedProcessSource( String encodedProcessSource ) {
-        this.encodedProcessSource = encodedProcessSource;
-    }
-
-    @Override
     public HTML getProcessIdText() {
         return processIdText;
     }
 
-    public Path getProcessAssetPath() {
-        return processAssetPath;
-    }
-
-    public String getEncodedProcessSource() {
-        return encodedProcessSource;
-    }
 }

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/details/advance/AdvancedViewProcessDefDetailsPresenter.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/details/advance/AdvancedViewProcessDefDetailsPresenter.java
@@ -100,9 +100,8 @@ public class AdvancedViewProcessDefDetailsPresenter extends
             view.getProcessNameText().setText( process.getName() );
             changeStyleRow( process.getName(), process.getVersion() );
         } else {
-            // set to null to ensure it's clear state
-            view.setEncodedProcessSource( null );
-            view.setProcessAssetPath( null );
+            // set to empty to ensure it's clear state
+            view.getProcessNameText().setText( "" );
         }
     }
 
@@ -218,10 +217,6 @@ public class AdvancedViewProcessDefDetailsPresenter extends
 
                     refreshServiceTasks( process.getServiceTasks() );
 
-                } else {
-                    // set to null to ensure it's clear state
-                    view.setEncodedProcessSource( null );
-                    view.setProcessAssetPath( null );
                 }
             }
         } ).getProcess(serverTemplateId, new ProcessDefinitionKey(serverTemplateId, deploymentId, processId));

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/details/basic/BasicProcessDefDetailsPresenter.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/details/basic/BasicProcessDefDetailsPresenter.java
@@ -59,14 +59,12 @@ public class BasicProcessDefDetailsPresenter extends BaseProcessDefDetailsPresen
             @Override
             public void callback( ProcessSummary process ) {
                 if (process != null) {
-                    view.setEncodedProcessSource( process.getEncodedProcessSource() );
                     view.getProcessNameText().setText( process.getName() );
 
                     changeStyleRow( process.getName(), process.getVersion() );
                 } else {
-                    // set to null to ensure it's clear state
-                    view.setEncodedProcessSource( null );
-                    view.setProcessAssetPath( null );
+                    // set to empty to ensure it's clear state
+                    view.getProcessNameText().setText( "" );
                 }
             }
         } ).getProcess(serverTemplateId, new ProcessDefinitionKey(serverTemplateId, deploymentId, processId));

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/details/multi/BaseProcessDefDetailsMultiViewImpl.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/details/multi/BaseProcessDefDetailsMultiViewImpl.java
@@ -16,8 +16,7 @@
 
 package org.jbpm.workbench.pr.client.editors.definition.details.multi;
 
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.IsWidget;
 import org.gwtbootstrap3.client.ui.Button;
@@ -28,20 +27,18 @@ import org.jbpm.workbench.pr.client.i18n.Constants;
 public abstract class BaseProcessDefDetailsMultiViewImpl extends Composite
         implements BaseProcessDefDetailsMultiPresenter.BaseProcessDefDetailsMultiView {
 
+    private Button newInstanceButton = GWT.create(Button.class);
+
+    public BaseProcessDefDetailsMultiViewImpl(){
+        newInstanceButton.setSize( ButtonSize.SMALL );
+        newInstanceButton.setIcon( IconType.PLAY );
+        newInstanceButton.setText( Constants.INSTANCE.New_Instance() );
+        newInstanceButton.addClickHandler( event -> createNewProcessInstance() );
+    }
+
     @Override
     public IsWidget getNewInstanceButton() {
-        return new Button() {{
-            setSize( ButtonSize.SMALL );
-            setIcon( IconType.PLAY );
-            setText( Constants.INSTANCE.New_Instance() );
-            addClickHandler( new ClickHandler() {
-
-                @Override
-                public void onClick( ClickEvent event ) {
-                    createNewProcessInstance();
-                }
-            } );
-        }};
+        return newInstanceButton;
     }
 
     protected abstract IsWidget getTabView();
@@ -49,4 +46,10 @@ public abstract class BaseProcessDefDetailsMultiViewImpl extends Composite
     protected abstract void closeDetails();
 
     protected abstract void createNewProcessInstance();
+
+    @Override
+    public void setNewInstanceButtonVisible(boolean visible) {
+        newInstanceButton.setVisible(visible);
+    }
+
 }

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/details/multi/advance/AdvancedProcessDefDetailsMultiPresenter.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/details/multi/advance/AdvancedProcessDefDetailsMultiPresenter.java
@@ -37,7 +37,7 @@ import org.uberfire.workbench.model.menu.impl.BaseMenuCustom;
 
 @Dependent
 @WorkbenchScreen(identifier = "Advanced Process Details Multi", preferredWidth = 500)
-public class AdvancedProcessDefDetailsMultiPresenter extends BaseProcessDefDetailsMultiPresenter {
+public class AdvancedProcessDefDetailsMultiPresenter extends BaseProcessDefDetailsMultiPresenter<AdvancedProcessDefDetailsMultiPresenter.AdvancedProcessDefDetailsMultiView> {
 
     public interface AdvancedProcessDefDetailsMultiView extends
                                                         UberView<AdvancedProcessDefDetailsMultiPresenter>,
@@ -45,9 +45,6 @@ public class AdvancedProcessDefDetailsMultiPresenter extends BaseProcessDefDetai
 
         IsWidget getOptionsButton();
     }
-
-    @Inject
-    public AdvancedProcessDefDetailsMultiView view;
 
     @Inject
     private AdvancedViewProcessDefDetailsPresenter detailPresenter;
@@ -65,23 +62,7 @@ public class AdvancedProcessDefDetailsMultiPresenter extends BaseProcessDefDetai
     @WorkbenchMenu
     public Menus buildMenu() {
         return MenuFactory
-                .newTopLevelCustomMenu(new MenuFactory.CustomMenuBuilder() {
-
-                    @Override
-                    public void push(MenuFactory.CustomMenuBuilder element) {
-                    }
-
-                    @Override
-                    public MenuItem build() {
-                        return new BaseMenuCustom<IsWidget>() {
-
-                            @Override
-                            public IsWidget build() {
-                                return view.getNewInstanceButton();
-                            }
-                        };
-                    }
-                }).endMenu()
+                .newTopLevelCustomMenu(newInstanceMenu).endMenu()
 
                 .newTopLevelCustomMenu(new MenuFactory.CustomMenuBuilder() {
 

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/details/multi/basic/BasicProcessDefDetailsMultiPresenter.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/details/multi/basic/BasicProcessDefDetailsMultiPresenter.java
@@ -20,33 +20,28 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
-import org.jbpm.workbench.pr.client.editors.definition.details.multi.BaseProcessDefDetailsMultiPresenter;
-import org.uberfire.ext.widgets.common.client.menu.RefreshMenuBuilder;
 import org.jbpm.workbench.pr.client.editors.definition.details.basic.BasicProcessDefDetailsPresenter;
+import org.jbpm.workbench.pr.client.editors.definition.details.multi.BaseProcessDefDetailsMultiPresenter;
 import org.uberfire.client.annotations.DefaultPosition;
 import org.uberfire.client.annotations.WorkbenchMenu;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
 import org.uberfire.client.mvp.UberView;
+import org.uberfire.ext.widgets.common.client.menu.RefreshMenuBuilder;
 import org.uberfire.workbench.model.CompassPosition;
 import org.uberfire.workbench.model.Position;
 import org.uberfire.workbench.model.menu.MenuFactory;
-import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.Menus;
-import org.uberfire.workbench.model.menu.impl.BaseMenuCustom;
 
 @Dependent
 @WorkbenchScreen(identifier = "Basic Process Details Multi", preferredWidth = 500)
-public class BasicProcessDefDetailsMultiPresenter extends BaseProcessDefDetailsMultiPresenter {
+public class BasicProcessDefDetailsMultiPresenter extends BaseProcessDefDetailsMultiPresenter<BasicProcessDefDetailsMultiPresenter.BasicProcessDefDetailsMultiView> {
 
     public interface BasicProcessDefDetailsMultiView extends
                                                      UberView<BasicProcessDefDetailsMultiPresenter>,
                                                      BaseProcessDefDetailsMultiPresenter.BaseProcessDefDetailsMultiView {
 
     }
-
-    @Inject
-    private BasicProcessDefDetailsMultiView view;
 
     @Inject
     private BasicProcessDefDetailsPresenter detailsPresenter;
@@ -68,24 +63,10 @@ public class BasicProcessDefDetailsMultiPresenter extends BaseProcessDefDetailsM
     @WorkbenchMenu
     public Menus buildMenu() {
         return MenuFactory
-                .newTopLevelCustomMenu(new MenuFactory.CustomMenuBuilder() {
-
-                    @Override
-                    public void push(MenuFactory.CustomMenuBuilder element) {
-                    }
-
-                    @Override
-                    public MenuItem build() {
-                        return new BaseMenuCustom<IsWidget>() {
-
-                            @Override
-                            public IsWidget build() {
-                                return view.getNewInstanceButton();
-                            }
-                        };
-                    }
-                }).endMenu()
+                .newTopLevelCustomMenu(newInstanceMenu).endMenu()
                 .newTopLevelCustomMenu(new RefreshMenuBuilder(this)).endMenu()
                 .build();
     }
+
+
 }

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/list/ProcessDefinitionListPresenter.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/list/ProcessDefinitionListPresenter.java
@@ -28,19 +28,19 @@ import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
-import org.jbpm.workbench.common.model.PortableQueryFilter;
 import org.jbpm.workbench.common.client.list.base.AbstractListView.ListView;
 import org.jbpm.workbench.common.client.list.base.AbstractScreenListPresenter;
 import org.jbpm.workbench.common.client.list.base.events.SearchEvent;
-import org.jbpm.workbench.pr.client.i18n.Constants;
+import org.jbpm.workbench.common.model.PortableQueryFilter;
 import org.jbpm.workbench.forms.client.display.providers.StartProcessFormDisplayProviderImpl;
 import org.jbpm.workbench.forms.client.display.views.PopupFormDisplayerView;
 import org.jbpm.workbench.forms.display.api.ProcessDisplayerConfig;
-import org.jbpm.workbench.pr.model.ProcessDefinitionKey;
-import org.jbpm.workbench.pr.model.ProcessSummary;
+import org.jbpm.workbench.pr.client.i18n.Constants;
 import org.jbpm.workbench.pr.events.NewProcessInstanceEvent;
 import org.jbpm.workbench.pr.events.ProcessDefSelectionEvent;
 import org.jbpm.workbench.pr.events.ProcessInstanceSelectionEvent;
+import org.jbpm.workbench.pr.model.ProcessDefinitionKey;
+import org.jbpm.workbench.pr.model.ProcessSummary;
 import org.jbpm.workbench.pr.service.ProcessRuntimeDataService;
 import org.uberfire.client.annotations.WorkbenchMenu;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
@@ -179,12 +179,16 @@ public class ProcessDefinitionListPresenter extends AbstractScreenListPresenter<
 
         if ( status == PlaceStatus.CLOSE ) {
             placeManager.goTo( placeIdentifier );
-            processDefSelected.fire( new ProcessDefSelectionEvent( processSummary.getProcessDefId(), processSummary.getDeploymentId(), selectedServerTemplate, processSummary.getProcessDefName() ) );
+            fireProcessDefSelectionEvent(processSummary);
         } else if ( status == PlaceStatus.OPEN && !close ) {
-            processDefSelected.fire( new ProcessDefSelectionEvent( processSummary.getProcessDefId(), processSummary.getDeploymentId(), selectedServerTemplate, processSummary.getProcessDefName() ) );
+            fireProcessDefSelectionEvent(processSummary);
         } else if ( status == PlaceStatus.OPEN && close ) {
             placeManager.closePlace( placeIdentifier );
         }
+    }
+
+    private void fireProcessDefSelectionEvent(final ProcessSummary processSummary) {
+        processDefSelected.fire(new ProcessDefSelectionEvent(processSummary.getProcessDefId(), processSummary.getDeploymentId(), selectedServerTemplate, processSummary.getProcessDefName(), processSummary.isDynamic()));
     }
 
     public void refreshNewProcessInstance( @Observes NewProcessInstanceEvent newProcessInstance ) {

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/list/ProcessDefinitionListViewImpl.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/list/ProcessDefinitionListViewImpl.java
@@ -20,23 +20,25 @@ import java.util.LinkedList;
 import java.util.List;
 import javax.enterprise.context.Dependent;
 
-import com.google.gwt.cell.client.ActionCell.Delegate;
+import com.google.gwt.cell.client.ActionCell;
+import com.google.gwt.cell.client.Cell;
 import com.google.gwt.cell.client.CompositeCell;
 import com.google.gwt.cell.client.HasCell;
 import com.google.gwt.cell.client.TextCell;
 import com.google.gwt.dom.client.BrowserEvents;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.dom.client.Style;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.view.client.CellPreviewEvent;
 import com.google.gwt.view.client.DefaultSelectionEventManager;
 import com.google.gwt.view.client.NoSelectionModel;
 import com.google.gwt.view.client.SelectionChangeEvent;
-import org.jbpm.workbench.pr.model.ProcessSummary;
 import org.jbpm.workbench.common.client.experimental.grid.base.ExtendedPagedTable;
 import org.jbpm.workbench.common.client.list.base.AbstractListView;
 import org.jbpm.workbench.common.client.util.ButtonActionCell;
 import org.jbpm.workbench.pr.client.i18n.Constants;
+import org.jbpm.workbench.pr.model.ProcessSummary;
 import org.uberfire.ext.services.shared.preferences.GridGlobalPreferences;
 import org.uberfire.ext.widgets.table.client.ColumnMeta;
 
@@ -174,12 +176,9 @@ public class ProcessDefinitionListViewImpl extends AbstractListView<ProcessSumma
         // actions (icons)
         List<HasCell<ProcessSummary, ?>> cells = new LinkedList<HasCell<ProcessSummary, ?>>();
 
-        cells.add(new ButtonActionCell<ProcessSummary>(constants.Start(), new Delegate<ProcessSummary>() {
-            @Override
-            public void execute(ProcessSummary process) {
-                presenter.openGenericForm(process.getProcessDefId(), process.getDeploymentId(), process.getProcessDefName());
-            }
-        }));
+        cells.add(new StartButtonActionCell(constants.Start(), (ProcessSummary process) ->
+                presenter.openGenericForm(process.getProcessDefId(), process.getDeploymentId(), process.getProcessDefName())
+        ));
 
         CompositeCell<ProcessSummary> cell = new CompositeCell<ProcessSummary>(cells);
         Column<ProcessSummary, ProcessSummary> actionsColumn = new Column<ProcessSummary, ProcessSummary>(cell) {
@@ -192,4 +191,17 @@ public class ProcessDefinitionListViewImpl extends AbstractListView<ProcessSumma
         return actionsColumn;
     }
 
+    protected class StartButtonActionCell extends ButtonActionCell<ProcessSummary> {
+
+        public StartButtonActionCell( final String text, final ActionCell.Delegate<ProcessSummary> delegate ) {
+            super( text, delegate );
+        }
+
+        @Override
+        public void render(final Cell.Context context, final ProcessSummary summary, final SafeHtmlBuilder sb ) {
+            if ( summary.isDynamic() == false ) {
+                super.render( context, summary, sb );
+            }
+        }
+    }
 }

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/definition/details/multi/BaseProcessDefDetailsMultiPresenterTest.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/definition/details/multi/BaseProcessDefDetailsMultiPresenterTest.java
@@ -33,10 +33,13 @@ import org.uberfire.mvp.PlaceRequest;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-public abstract class BaseProcessDefDetailsMultiPresenterTest {
+public abstract class BaseProcessDefDetailsMultiPresenterTest<T extends BaseProcessDefDetailsMultiPresenter.BaseProcessDefDetailsMultiView> {
 
     @Mock
     PlaceManager placeManager;
+
+    @Mock
+    T view;
 
     @Mock
     protected EventSourceMock<ProcessDefSelectionEvent> processDefSelectionEvent = new EventSourceMock<ProcessDefSelectionEvent>();

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/definition/details/multi/advance/AdvancedProcessDefDetailsMultiPresenterTest.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/definition/details/multi/advance/AdvancedProcessDefDetailsMultiPresenterTest.java
@@ -22,7 +22,8 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 
 @RunWith(GwtMockitoTestRunner.class)
-public class AdvancedProcessDefDetailsMultiPresenterTest extends BaseProcessDefDetailsMultiPresenterTest {
+public class AdvancedProcessDefDetailsMultiPresenterTest
+        extends BaseProcessDefDetailsMultiPresenterTest<AdvancedProcessDefDetailsMultiPresenter.AdvancedProcessDefDetailsMultiView> {
 
     @InjectMocks
     AdvancedProcessDefDetailsMultiPresenter presenter;

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/definition/details/multi/basic/BasicProcessDefDetailsMultiPresenterTest.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/definition/details/multi/basic/BasicProcessDefDetailsMultiPresenterTest.java
@@ -23,7 +23,8 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 
 @RunWith(GwtMockitoTestRunner.class)
-public class BasicProcessDefDetailsMultiPresenterTest extends BaseProcessDefDetailsMultiPresenterTest {
+public class BasicProcessDefDetailsMultiPresenterTest
+        extends BaseProcessDefDetailsMultiPresenterTest<BasicProcessDefDetailsMultiPresenter.BasicProcessDefDetailsMultiView> {
 
     @InjectMocks
     BasicProcessDefDetailsMultiPresenter presenter;

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/definition/list/ProcessDefinitionListPresenterTest.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/definition/list/ProcessDefinitionListPresenterTest.java
@@ -108,12 +108,11 @@ public class ProcessDefinitionListPresenterTest {
 
     @Test
     public void testProcessDefNameDefinitionPropagation(){
-        String processDefName = "testProcessDefName";
-
-        ProcessSummary processSummary = new ProcessSummary();
+        final ProcessSummary processSummary = new ProcessSummary();
         processSummary.setProcessDefId("testProcessDefId");
         processSummary.setDeploymentId("testDeploymentId");
-        processSummary.setProcessDefName(processDefName);
+        processSummary.setProcessDefName("testProcessDefName");
+        processSummary.setDynamic(false);
 
         when(placeManager.getStatus(any(PlaceRequest.class))).thenReturn(PlaceStatus.CLOSE);
         presenter.selectProcessDefinition(processSummary, true);
@@ -121,7 +120,11 @@ public class ProcessDefinitionListPresenterTest {
         verify(processDefSelectionEvent).fire(any(ProcessDefSelectionEvent.class));
         ArgumentCaptor<ProcessDefSelectionEvent> argument = ArgumentCaptor.forClass( ProcessDefSelectionEvent.class );
         verify( processDefSelectionEvent).fire(argument.capture());
-        assertEquals( processDefName, argument.getValue().getProcessDefName() );
+        final ProcessDefSelectionEvent event = argument.getValue();
+        assertEquals( processSummary.getProcessDefName(), event.getProcessDefName() );
+        assertEquals( processSummary.getDeploymentId(), event.getDeploymentId() );
+        assertEquals( processSummary.getProcessDefId(), event.getProcessId() );
+        assertEquals( processSummary.isDynamic(), event.isDynamic() );
     }
 
     @Test


### PR DESCRIPTION
Blocked start process instances from process definition list, process definition details and process instance list.
Moved mapper logic between ProcessDefinition and ProcessSummary into a single place/class.
Removed unsuded attributtes from ProcessSummary
Updated QuickNewProcessInstance to have a single dropdown with process definitions grouped by container.
Updated QuickNewProcessInstance dropdown style to match PatternFly guidelines