### PR TITLE
Case Actions: Separate status from type in model

### DIFF
--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-api/src/main/java/org/jbpm/workbench/cm/model/CaseActionSummary.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-api/src/main/java/org/jbpm/workbench/cm/model/CaseActionSummary.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
+import org.jbpm.workbench.cm.util.CaseActionStatus;
 import org.jbpm.workbench.cm.util.CaseActionType;
 
 @Bindable
@@ -30,10 +31,11 @@ public class CaseActionSummary {
     private Long id;
     private String name;
     private String type;
-    private String actualOwner;
-    private CaseActionType actionType;
     private Date createdOn;
     private String stageId;
+    private String actualOwner;
+    private CaseActionType actionType;
+    private CaseActionStatus actionStatus;
 
     public CaseActionSummary() {
     }
@@ -66,6 +68,22 @@ public class CaseActionSummary {
         this.type = type;
     }
 
+    public Date getCreatedOn() {
+        return createdOn;
+    }
+
+    public void setCreatedOn(Date createdOn) {
+        this.createdOn = createdOn;
+    }
+
+    public String getStageId() {
+        return stageId;
+    }
+
+    public void setStageId(String stageId) {
+        this.stageId = stageId;
+    }
+
     public String getActualOwner() {
         return actualOwner;
     }
@@ -82,21 +100,9 @@ public class CaseActionSummary {
         this.actionType = actionType;
     }
 
-    public Date getCreatedOn() {
-        return createdOn;
-    }
+    public CaseActionStatus getActionStatus() { return actionStatus; }
 
-    public void setCreatedOn(Date createdOn) {
-        this.createdOn = createdOn;
-    }
-
-    public String getStageId() {
-        return stageId;
-    }
-
-    public void setStageId(String stageId) {
-        this.stageId = stageId;
-    }
+    public void setActionStatus(CaseActionStatus actionStatus) { this.actionStatus = actionStatus; }
 
     @Override
     public boolean equals(Object o) {
@@ -122,10 +128,11 @@ public class CaseActionSummary {
                 " id='" + id + '\'' +
                 " name='" + name + '\'' +
                 " type='" + type + '\'' +
-                " actualOwner='" + actualOwner + '\'' +
-                " actionType='" + actionType + '\'' +
                 " createdOn='" + createdOn + '\'' +
                 " stageId='" + stageId + '\'' +
+                " actualOwner='" + actualOwner + '\'' +
+                " actionType='" + actionType + '\'' +
+                " actionStatus='" + actionStatus + '\'' +
                 '}';
     }
 
@@ -152,13 +159,8 @@ public class CaseActionSummary {
             return this;
         }
 
-        public Builder actualOwner(String actualOwner) {
-            caseActionSummary.setActualOwner(actualOwner);
-            return this;
-        }
-
-        public Builder status(CaseActionType status) {
-            caseActionSummary.setActionType(status);
+        public Builder createdOn(Date createdOn) {
+            caseActionSummary.setCreatedOn(createdOn);
             return this;
         }
 
@@ -167,8 +169,8 @@ public class CaseActionSummary {
             return this;
         }
 
-        public Builder createdOn(Date createdOn) {
-            caseActionSummary.setCreatedOn(createdOn);
+        public Builder actualOwner(String actualOwner) {
+            caseActionSummary.setActualOwner(actualOwner);
             return this;
         }
 
@@ -176,6 +178,12 @@ public class CaseActionSummary {
             caseActionSummary.setActionType(actionType);
             return this;
         }
+
+        public Builder actionStatus(CaseActionStatus actionStatus) {
+            caseActionSummary.setActionStatus(actionStatus);
+            return this;
+        }
+
     }
 
 }

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-api/src/main/java/org/jbpm/workbench/cm/util/CaseActionStatus.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-api/src/main/java/org/jbpm/workbench/cm/util/CaseActionStatus.java
@@ -16,11 +16,11 @@
 
 package org.jbpm.workbench.cm.util;
 
-public enum CaseActionType {
+public enum CaseActionStatus {
 
-    AD_HOC_TASK,
+    AVAILABLE,
 
-    DYNAMIC_USER_TASK,
+    IN_PROGRESS,
 
-    DYNAMIC_SUBPROCESS_TASK,
+    COMPLETED
 }

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/src/main/java/org/jbpm/workbench/cm/backend/server/CaseActionAdHocMapper.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/src/main/java/org/jbpm/workbench/cm/backend/server/CaseActionAdHocMapper.java
@@ -19,10 +19,12 @@ package org.jbpm.workbench.cm.backend.server;
 import java.util.function.Function;
 
 import org.jbpm.workbench.cm.model.CaseActionSummary;
+import org.jbpm.workbench.cm.util.CaseActionStatus;
 import org.jbpm.workbench.cm.util.CaseActionType;
 import org.kie.server.api.model.cases.CaseAdHocFragment;
 
 public class CaseActionAdHocMapper implements Function<CaseAdHocFragment, CaseActionSummary> {
+
     private String stageId;
 
     public CaseActionAdHocMapper(String stageId) {
@@ -37,9 +39,10 @@ public class CaseActionAdHocMapper implements Function<CaseAdHocFragment, CaseAc
 
         return CaseActionSummary.builder()
                 .name(adHocFragment.getName())
-                .status(CaseActionType.AD_HOC)
                 .type(adHocFragment.getType())
                 .stageId(stageId)
+                .actionType(CaseActionType.AD_HOC_TASK)
+                .actionStatus(CaseActionStatus.AVAILABLE)
                 .build();
     }
 

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/src/main/java/org/jbpm/workbench/cm/backend/server/CaseActionNodeInstanceMapper.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/src/main/java/org/jbpm/workbench/cm/backend/server/CaseActionNodeInstanceMapper.java
@@ -19,17 +19,17 @@ package org.jbpm.workbench.cm.backend.server;
 import java.util.function.Function;
 
 import org.jbpm.workbench.cm.model.CaseActionSummary;
-import org.jbpm.workbench.cm.util.CaseActionType;
+import org.jbpm.workbench.cm.util.CaseActionStatus;
 import org.kie.server.api.model.instance.NodeInstance;
 
 public class CaseActionNodeInstanceMapper implements Function<NodeInstance, CaseActionSummary> {
 
     private String actualOwner;
-    private CaseActionType actionType;
+    private CaseActionStatus actionStatus;
 
-    public CaseActionNodeInstanceMapper(String actualOwner, CaseActionType actionType) {
+    public CaseActionNodeInstanceMapper(String actualOwner, CaseActionStatus actionStatus) {
         this.actualOwner = actualOwner;
-        this.actionType = actionType;
+        this.actionStatus = actionStatus;
     }
 
     @Override
@@ -38,12 +38,12 @@ public class CaseActionNodeInstanceMapper implements Function<NodeInstance, Case
             return null;
         }
         return CaseActionSummary.builder()
+                .id(nodeInstance.getId())
                 .name(nodeInstance.getName())
-                .createdOn(nodeInstance.getDate())
                 .type(nodeInstance.getNodeType())
-                .id(nodeInstance.getWorkItemId())
+                .createdOn(nodeInstance.getDate())
                 .actualOwner(actualOwner)
-                .actionType(actionType)
+                .actionStatus(actionStatus)
                 .build();
     }
 

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/src/main/java/org/jbpm/workbench/cm/backend/server/RemoteCaseManagementServiceImpl.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/src/main/java/org/jbpm/workbench/cm/backend/server/RemoteCaseManagementServiceImpl.java
@@ -34,7 +34,7 @@ import org.jbpm.workbench.cm.model.CaseMilestoneSummary;
 import org.jbpm.workbench.cm.model.ProcessDefinitionSummary;
 import org.jbpm.workbench.cm.service.CaseManagementService;
 import org.jbpm.workbench.cm.util.Actions;
-import org.jbpm.workbench.cm.util.CaseActionType;
+import org.jbpm.workbench.cm.util.CaseActionStatus;
 import org.jbpm.workbench.cm.util.CaseInstanceSearchRequest;
 import org.jbpm.workbench.cm.util.CaseInstanceSortBy;
 import org.jbpm.workbench.cm.util.CaseMilestoneSearchRequest;
@@ -201,7 +201,7 @@ public class RemoteCaseManagementServiceImpl implements CaseManagementService {
                         (NODE_TYPE_HUMAN_TASK.contains(s.getNodeType()) ?
                                 userTaskServicesClient.findTaskByWorkItemId(s.getWorkItemId()).getActualOwner() :
                                 ""),
-                        CaseActionType.INPROGRESS).apply(s))
+                        CaseActionStatus.IN_PROGRESS).apply(s))
                 .collect(toList());
     }
 
@@ -218,7 +218,7 @@ public class RemoteCaseManagementServiceImpl implements CaseManagementService {
                         (NODE_TYPE_HUMAN_TASK.contains(s.getNodeType()) ?
                                 userTaskServicesClient.findTaskByWorkItemId(s.getWorkItemId()).getActualOwner() :
                                 ""),
-                        CaseActionType.COMPLETED).apply(s))
+                        CaseActionStatus.COMPLETED).apply(s))
                 .collect(toList());
     }
 

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/src/test/java/org/jbpm/workbench/cm/backend/server/CaseInstanceMapperTest.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/src/test/java/org/jbpm/workbench/cm/backend/server/CaseInstanceMapperTest.java
@@ -80,7 +80,7 @@ public class CaseInstanceMapperTest {
                 caseActionSummary = casl.get(i);
                 assertEquals(caseActionSummary.getName(), caseAdHocFragment.getName());
                 assertEquals(stageId, caseActionSummary.getStageId());
-                assertEquals(CaseActionType.AD_HOC, caseActionSummary.getActionType());
+                assertEquals(CaseActionType.AD_HOC_TASK, caseActionSummary.getActionType());
             }
         }
     }

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/src/test/java/org/jbpm/workbench/cm/backend/server/RemoteCaseManagementServiceImplTest.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/src/test/java/org/jbpm/workbench/cm/backend/server/RemoteCaseManagementServiceImplTest.java
@@ -27,7 +27,7 @@ import org.jbpm.workbench.cm.model.CaseDefinitionSummary;
 import org.jbpm.workbench.cm.model.CaseInstanceSummary;
 import org.jbpm.workbench.cm.model.CaseMilestoneSummary;
 import org.jbpm.workbench.cm.util.Actions;
-import org.jbpm.workbench.cm.util.CaseActionType;
+import org.jbpm.workbench.cm.util.CaseActionStatus;
 import org.jbpm.workbench.cm.util.CaseInstanceSearchRequest;
 import org.jbpm.workbench.cm.util.CaseInstanceSortBy;
 import org.jbpm.workbench.cm.util.CaseMilestoneSearchRequest;
@@ -448,8 +448,8 @@ public class RemoteCaseManagementServiceImplTest {
         List<CaseActionSummary> actionsSummaries = testedService.getInProgressActions(containerId, caseId);
 
         assertEquals(2, actionsSummaries.size());
-        assertEquals(CaseActionType.INPROGRESS, actionsSummaries.get(0).getActionType());
-        assertEquals(CaseActionType.INPROGRESS, actionsSummaries.get(1).getActionType());
+        assertEquals(CaseActionStatus.IN_PROGRESS, actionsSummaries.get(0).getActionStatus());
+        assertEquals(CaseActionStatus.IN_PROGRESS, actionsSummaries.get(1).getActionStatus());
         assertEquals(taskActualOwner, actionsSummaries.get(0).getActualOwner());
         assertTrue(isNullOrEmpty(actionsSummaries.get(1).getActualOwner()));
 

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/actions/CaseActionsPresenter.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/actions/CaseActionsPresenter.java
@@ -32,6 +32,7 @@ import org.jbpm.workbench.cm.model.CaseInstanceSummary;
 import org.jbpm.workbench.cm.model.CaseStageSummary;
 import org.jbpm.workbench.cm.model.ProcessDefinitionSummary;
 import org.jbpm.workbench.cm.util.Actions;
+import org.jbpm.workbench.cm.util.CaseActionStatus;
 import org.jbpm.workbench.cm.util.CaseActionType;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchScreen;
@@ -85,9 +86,9 @@ public class CaseActionsPresenter extends AbstractCaseInstancePresenter<CaseActi
         refreshData(true);
     }
 
-    protected void showAddDynUserTaskAction(CaseActionType caseActionType) {
+    protected void showDynamicAction(CaseActionType caseActionType) {
         switch (caseActionType) {
-           case ADD_DYNAMIC_USER_TASK: {
+           case DYNAMIC_USER_TASK: {
                 newActionView.show(caseActionType, () ->
                         addDynamicUserTaskAction(
                                 newActionView.getTaskName(),
@@ -97,7 +98,7 @@ public class CaseActionsPresenter extends AbstractCaseInstancePresenter<CaseActi
                                 newActionView.getStageId()));
                 break;
             }
-            case ADD_DYNAMIC_SUBPROCESS_TASK: {
+            case DYNAMIC_SUBPROCESS_TASK: {
                 newActionView.show(caseActionType, () ->
                         addDynamicSubprocessTaskAction(
                                 newActionView.getProcessDefinitionName(),
@@ -139,11 +140,13 @@ public class CaseActionsPresenter extends AbstractCaseInstancePresenter<CaseActi
                 List<CaseActionSummary> availableActions = new ArrayList<>();
                 availableActions.add(CaseActionSummary.builder()
                         .name(translationService.getTranslation(NEW_USER_TASK))
-                        .status(CaseActionType.ADD_DYNAMIC_USER_TASK)
+                        .actionType(CaseActionType.DYNAMIC_USER_TASK)
+                        .actionStatus(CaseActionStatus.AVAILABLE)
                         .build());
                 availableActions.add(CaseActionSummary.builder()
                         .name(translationService.getTranslation(NEW_PROCESS_TASK))
-                        .status(CaseActionType.ADD_DYNAMIC_SUBPROCESS_TASK)
+                        .actionType(CaseActionType.DYNAMIC_SUBPROCESS_TASK)
+                        .actionStatus(CaseActionStatus.AVAILABLE)
                         .build());
                 availableActions.addAll(actions.getAvailableActions());
                 view.setAvailableActionsList(availableActions);

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/actions/NewActionViewImpl.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/actions/NewActionViewImpl.java
@@ -175,7 +175,7 @@ public class NewActionViewImpl implements CaseActionsPresenter.NewActionView {
             validForm = false;
         }
         switch (caseActionType) {
-            case ADD_DYNAMIC_USER_TASK: {
+            case DYNAMIC_USER_TASK: {
                 if (isNullOrEmpty(actionUsersInput.getValue()) && isNullOrEmpty(actionGroupsInput.getValue())) {
                     actionUsersInput.focus();
                     actionUsersGroup.setValidationState(ValidationState.ERROR);
@@ -185,7 +185,7 @@ public class NewActionViewImpl implements CaseActionsPresenter.NewActionView {
                 }
                 break;
             }
-            case ADD_DYNAMIC_SUBPROCESS_TASK: {
+            case DYNAMIC_SUBPROCESS_TASK: {
                 if (isNullOrEmpty(processDefinitionsList.getValue())) {
                     processDefinitionsList.getElement().focus();
                     actionProcessDefinitionsGroup.setValidationState(ValidationState.ERROR);
@@ -267,7 +267,7 @@ public class NewActionViewImpl implements CaseActionsPresenter.NewActionView {
     public void setCaseActionType(CaseActionType caseActionType) {
         this.caseActionType = caseActionType;
         switch (caseActionType) {
-            case ADD_DYNAMIC_USER_TASK: {
+            case DYNAMIC_USER_TASK: {
                 modalTitle.setTextContent(translationService.format(NEW_USER_TASK));
                 removeCSSClass(this.actionDescGroup.getElement(), "hidden");
                 removeCSSClass(this.actionUsersGroup.getElement(), "hidden");
@@ -275,7 +275,7 @@ public class NewActionViewImpl implements CaseActionsPresenter.NewActionView {
                 addCSSClass(this.actionProcessDefinitionsGroup.getElement(), "hidden");
                 break;
             }
-            case ADD_DYNAMIC_SUBPROCESS_TASK: {
+            case DYNAMIC_SUBPROCESS_TASK: {
                 modalTitle.setTextContent(translationService.format(NEW_PROCESS_TASK));
                 addCSSClass(this.actionDescGroup.getElement(), "hidden");
                 addCSSClass(this.actionUsersGroup.getElement(), "hidden");

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/test/java/org/jbpm/workbench/cm/client/actions/ActionsPresenterTest.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/test/java/org/jbpm/workbench/cm/client/actions/ActionsPresenterTest.java
@@ -73,7 +73,6 @@ public class ActionsPresenterTest extends AbstractCaseInstancePresenterTest {
         return CaseActionSummary.builder()
                 .id(Long.valueOf(1))
                 .name("actionName")
-                .status(CaseActionType.INPROGRESS)
                 .build();
     }
 
@@ -112,8 +111,8 @@ public class ActionsPresenterTest extends AbstractCaseInstancePresenterTest {
 
         verify(caseAllActionsView).setAvailableActionsList(captor.capture());
         assertEquals(caseActionSummaryList.size() + 2, captor.getValue().size());
-        assertEquals(CaseActionType.ADD_DYNAMIC_USER_TASK, ((CaseActionSummary) captor.getValue().get(0)).getActionType());
-        assertEquals(CaseActionType.ADD_DYNAMIC_SUBPROCESS_TASK, ((CaseActionSummary) captor.getValue().get(1)).getActionType());
+        assertEquals(CaseActionType.DYNAMIC_USER_TASK, ((CaseActionSummary) captor.getValue().get(0)).getActionType());
+        assertEquals(CaseActionType.DYNAMIC_SUBPROCESS_TASK, ((CaseActionSummary) captor.getValue().get(1)).getActionType());
 
         verify(caseAllActionsView).setInProgressActionsList(caseActionSummaryList);
         verify(caseAllActionsView).setCompletedActionsList(caseActionSummaryList);

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-showcase/src/main/java/org/jbpm/workbench/cm/server/MockCaseManagementService.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-showcase/src/main/java/org/jbpm/workbench/cm/server/MockCaseManagementService.java
@@ -38,6 +38,7 @@ import org.jbpm.workbench.cm.model.CaseMilestoneSummary;
 import org.jbpm.workbench.cm.model.CaseRoleAssignmentSummary;
 import org.jbpm.workbench.cm.model.CaseStageSummary;
 import org.jbpm.workbench.cm.model.ProcessDefinitionSummary;
+import org.jbpm.workbench.cm.util.CaseActionStatus;
 import org.jbpm.workbench.cm.util.CaseActionType;
 import org.jbpm.workbench.cm.util.CaseInstanceSearchRequest;
 import org.jbpm.workbench.cm.util.CaseMilestoneSearchRequest;
@@ -226,17 +227,17 @@ public class MockCaseManagementService extends RemoteCaseManagementServiceImpl {
 
     public List<CaseActionSummary> getAdHocFragments(String containerId, String caseId) {
         return ofNullable(caseActionMap.get(caseId)).orElse(emptyList()).stream()
-                .filter(c -> CaseActionType.AD_HOC == c.getActionType()).collect(toList());
+                .filter(c -> CaseActionType.AD_HOC_TASK == c.getActionType()).collect(toList());
     }
 
     public List<CaseActionSummary> getInProgressActions(String containerId, String caseId) {
         return ofNullable(caseActionMap.get(caseId)).orElse(emptyList()).stream()
-                .filter(c -> CaseActionType.INPROGRESS == c.getActionType()).collect(toList());
+                .filter(c -> CaseActionStatus.IN_PROGRESS == c.getActionStatus()).collect(toList());
     }
 
     public List<CaseActionSummary> getCompletedActions(String containerId, String caseId) {
         return ofNullable(caseActionMap.get(caseId)).orElse(emptyList()).stream()
-                .filter(c -> CaseActionType.COMPLETED == c.getActionType()).collect(toList());
+                .filter(c -> CaseActionStatus.COMPLETED == c.getActionStatus()).collect(toList());
     }
 
     @Override
@@ -247,7 +248,7 @@ public class MockCaseManagementService extends RemoteCaseManagementServiceImpl {
                 .name(name)
                 .actualOwner(actors)
                 .type("Human Task")
-                .status(CaseActionType.INPROGRESS)
+                .actionStatus(CaseActionStatus.IN_PROGRESS)
                 .createdOn(new Date())
                 .build();
         actionSummaryList.add(action);
@@ -261,7 +262,7 @@ public class MockCaseManagementService extends RemoteCaseManagementServiceImpl {
                 .name(name)
                 .actualOwner(actors)
                 .type("Human Task")
-                .status(CaseActionType.INPROGRESS)
+                .actionStatus(CaseActionStatus.IN_PROGRESS)
                 .createdOn(new Date())
                 .build();
         actionSummaryList.add(action);
@@ -274,7 +275,7 @@ public class MockCaseManagementService extends RemoteCaseManagementServiceImpl {
         final CaseActionSummary action = CaseActionSummary.builder()
                 .id(actionIdLongenerator++)
                 .name(adHocName)
-                .status(CaseActionType.INPROGRESS)
+                .actionStatus(CaseActionStatus.IN_PROGRESS)
                 .createdOn(new Date())
                 .build();
         actionSummaryList.add(action);
@@ -287,7 +288,7 @@ public class MockCaseManagementService extends RemoteCaseManagementServiceImpl {
         final CaseActionSummary action = CaseActionSummary.builder()
                 .id(actionIdLongenerator++)
                 .name(adHocName)
-                .status(CaseActionType.INPROGRESS)
+                .actionStatus(CaseActionStatus.IN_PROGRESS)
                 .createdOn(new Date())
                 .build();
         actionSummaryList.add(action);
@@ -300,7 +301,7 @@ public class MockCaseManagementService extends RemoteCaseManagementServiceImpl {
         final CaseActionSummary action = CaseActionSummary.builder()
                 .id(actionIdLongenerator++)
                 .name("subprocess: " + processId)
-                .status(CaseActionType.INPROGRESS)
+                .actionStatus(CaseActionStatus.IN_PROGRESS)
                 .createdOn(new Date())
                 .build();
         actionSummaryList.add(action);
@@ -313,7 +314,7 @@ public class MockCaseManagementService extends RemoteCaseManagementServiceImpl {
         final CaseActionSummary action = CaseActionSummary.builder()
                 .id(actionIdLongenerator++)
                 .name("subprocess: " + processId + " inStage:" + stageId)
-                .status(CaseActionType.INPROGRESS)
+                .actionStatus(CaseActionStatus.IN_PROGRESS)
                 .createdOn(new Date())
                 .build();
         actionSummaryList.add(action);

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-showcase/src/main/resources/case_actions.json
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-showcase/src/main/resources/case_actions.json
@@ -4,51 +4,54 @@
     "name": "Task1",
     "type": "Human Task",
     "actualOwner": "Joe",
-    "actionType": "INPROGRESS"
+    "actionStatus": "IN_PROGRESS"
   },
   {
     "id": "2",
     "name": "Task2_noHumanTask",
     "type": "Service Task",
-    "actionType": "INPROGRESS"
+    "actionStatus": "IN_PROGRESS"
   },
   {
     "id": "3",
     "name": "Task3",
     "type": "Human Task",
     "actualOwner": "Jan",
-    "actionType": "INPROGRESS"
+    "actionStatus": "IN_PROGRESS"
   },
   {
     "id": "4",
     "name": "Task4",
     "type": "Human Task",
     "actualOwner": "Max",
-    "actionType": "INPROGRESS"
+    "actionStatus": "IN_PROGRESS"
   },
   {
     "id": "5",
     "name": "Task5",
     "type": "Human Task",
     "actualOwner": "Max",
-    "actionType": "COMPLETED"
+    "actionStatus": "COMPLETED"
   },
   {
     "id": "6",
     "name": "adhoc1",
     "type": "SubProcessNode",
-    "actionType": "AD_HOC"
+    "actionType": "AD_HOC_TASK",
+    "actionStatus": "AVAILABLE"
   },
   {
     "id": "7",
     "name": "Task6",
     "type": "Human Task",
-    "actionType": "AD_HOC"
+    "actionType": "AD_HOC_TASK",
+    "actionStatus": "AVAILABLE"
   },
   {
     "id": "8",
     "name": "adhoc2",
     "type": "Human Task",
-    "actionType": "AD_HOC"
+    "actionType": "AD_HOC_TASK",
+    "actionStatus": "AVAILABLE"
   }
 ]

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-showcase/src/main/resources/case_stages.json
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-showcase/src/main/resources/case_stages.json
@@ -7,13 +7,15 @@
       {
         "id": "100",
         "name": "adhoc_stage1_1",
-        "actionType": "AD_HOC",
+        "actionType": "AD_HOC_TASK",
+        "actionStatus": "AVAILABLE",
         "stageId": "Stage1"
       },
       {
         "id": "101",
         "name": "adhoc_stage1_2",
-        "actionType": "AD_HOC",
+        "actionType": "AD_HOC_TASK",
+        "actionStatus": "AVAILABLE",
         "stageId": "Stage1"
       }
     ]
@@ -32,13 +34,15 @@
       {
         "id": "300",
         "name": "adhoc_stage3_1",
-        "actionType": "AD_HOC",
+        "actionType": "AD_HOC_TASK",
+        "actionStatus": "AVAILABLE",
         "stageId": "Stage3"
       },
       {
         "id": "301",
         "name": "adhoc_stage3_2",
-        "actionType": "AD_HOC",
+        "actionType": "AD_HOC_TASK",
+        "actionStatus": "AVAILABLE",
         "stageId": "Stage3"
       }
     ]


### PR DESCRIPTION
Case Action type can be: 
- AD_HOC_TASK,
- DYNAMIC_USER_TASK
- DYNAMIC_SUBPROCESS_TASK

Case Action status can be:
- AVAILABLE,
- IN_PROGRESS
- COMPLETED

The idea behind status AVAILABLE is quite simple.
All dynamic actions will have status AVAILABLE throughout the entire case life-cycle. 
The same goes for ALL ad-hoc tasks regardless of their scope (case level or stage level). This treatment of ad-hoc tasks is safe because when displaying available ad-hoc actions which are part of a stage, the stage status will determine whether its ad-hoc actions will be exposed to the case worker or not (i.e. only if the stage status is Available, its ad-hoc actions will be offered).

Have also changed the mapping of Case Action "id" property in CaseActionNodeInstanceMapper, so it's mapped to Node Instance "id" instead of "work-item-id". This change doesn't influence the implemented use of work-item-id in retrieving "In progress/Completed" node instances.

In addition, have done a smaller re-factoring around structuring the code, removing unused pieces and enhancing overall readability.
